### PR TITLE
Added version detection for Oracle ATG Web Commerce

### DIFF
--- a/VersionDetect/atg.py
+++ b/VersionDetect/atg.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# This is a part of CMSeeK, check the LICENSE file for more information
+# Copyright (c) 2018 Tuhinshubhra
+
+# Oracle ATG version detection
+# Rev 1
+
+import cmseekdb.basic as cmseek
+import re
+from base64 import b64decode
+
+
+def start(headers):
+    cmseek.statement('Detecting version using atg_version [Method 1 of 1]')
+    try:
+        encoded_version = re.search('X-ATG-Version: version=(.+)', headers).group(1)
+        version = b64decode(encoded_version).decode('utf-8')
+        version = re.search('ATGPlatform\/([\d\.]+)', version).group(1)
+    except:
+        version = None
+
+    if version:
+        cmseek.success('Oracle ATG version ' + cmseek.bold + version + cmseek.cln + ' detected')
+    else:
+        cmseek.error('Oracle ATG version detection failed!')
+        version = '0'
+
+    return version

--- a/VersionDetect/detect.py
+++ b/VersionDetect/detect.py
@@ -3,7 +3,7 @@
 # This is a part of CMSeeK, check the LICENSE file for more information
 # Copyright (c) 2018 Tuhinshubhra
 
-def start(id, url, ua, ga, source, ga_content):
+def start(id, url, ua, ga, source, ga_content, headers):
     if id == "wp":
         # trust me more will be added soon
         import VersionDetect.wp as wpverdetect
@@ -229,3 +229,7 @@ def start(id, url, ua, ga, source, ga_content):
         import VersionDetect.mg as mgverdetect
         mgver = mgverdetect.start(url, ua)
         return mgver
+    elif id == 'oracle_atg':
+        import VersionDetect.atg as atgverdetect
+        atgver = atgverdetect.start(headers)
+        return atgver

--- a/cmseekdb/cmss.py
+++ b/cmseekdb/cmss.py
@@ -889,6 +889,6 @@ cmshop = {
 oracle_atg = {
     'name': 'Oracle ATG Web Commerce',
     'url': 'http://www.oracle.com/us/products/applications/atg/web-commerce/web-commerce-search-330138.html',
-    'vd': '0',
+    'vd': '1',
     'deeps': '0'
 }

--- a/cmseekdb/core.py
+++ b/cmseekdb/core.py
@@ -111,7 +111,7 @@ def main_proc(site,cua):
         elif cms_info['vd'] == '1':
             cmseek.success('Starting version detection')
             cms_version = '0' # Failsafe measure
-            cms_version = version_detect.start(cms, site, cua, ga, scode, ga_content)
+            cms_version = version_detect.start(cms, site, cua, ga, scode, ga_content, headers)
             cmseek.clearscreen()
             cmseek.banner("CMS Scan Results")
             result.target(site)


### PR DESCRIPTION
Version detection is done using headers. There was no way to access headers in detect.py so I added headers as an argument. Oracle ATG's version is base64 encoded so it needs to be decoded. Decoded result looks like the following:

- ATGPlatform/9.2 [ DPSLicense/0 B2CLicense/0  ]

- ATGPlatform/9.2 [ DPSLicense/0 B2CLicense/0  ]

- ATGPlatform/10.1.2

So, a regex is used to extract the version from the decoded result.