### PR TITLE
Bugfix/wp regex

### DIFF
--- a/deepscans/wp/pluginsdetect.py
+++ b/deepscans/wp/pluginsdetect.py
@@ -9,7 +9,7 @@ import json
 
 def start(source):
     cmseek.info('Starting passive plugin enumeration')
-    plug_regex = re.compile('wp-content/plugins/(.*?)/.*?[css|js].*?ver=([0-9\.]*)')
+    plug_regex = re.compile('wp-content/plugins/([^/]+)/.+ver=([0-9\.]+)')
     results = plug_regex.findall(source)
     plugins = []
     found = 0

--- a/deepscans/wp/themedetect.py
+++ b/deepscans/wp/themedetect.py
@@ -11,7 +11,7 @@ def start(source,url,ua):
     ## plug_file = open('database/themes.json', 'r')
     ## plug_data = plug_file.read()
     ## plug_json = json.loads(plug_data)
-	plug_regex = re.compile('wp-content/themes/([^/]+)/.+ver=([0-9\.]+)')
+    plug_regex = re.compile('wp-content/themes/([^/]+)/.+ver=([0-9\.]+)')
     results = plug_regex.findall(source)
     themes = []
     found = 0

--- a/deepscans/wp/themedetect.py
+++ b/deepscans/wp/themedetect.py
@@ -11,7 +11,7 @@ def start(source,url,ua):
     ## plug_file = open('database/themes.json', 'r')
     ## plug_data = plug_file.read()
     ## plug_json = json.loads(plug_data)
-    plug_regex = re.compile('wp-content/themes/(.*?)/.*?[css|js].*?ver=([0-9\.]*)')
+	plug_regex = re.compile('wp-content/themes/([^/]+)/.+ver=([0-9\.]+)')
     results = plug_regex.findall(source)
     themes = []
     found = 0


### PR DESCRIPTION
I ran CMSeeK against one of my WP sites and it hung up on "Starting passive theme enumeration". After 10 minutes I investigated and found the regex to be the culprit.

Testing the original regex on [https://regex101.com/](https://regex101.com/) caused it to spit out a **"catastrophic backtracking"** error.

This PR replaces the theme and plugin regexs with simpler ones that achieve the same with less effort - match wp-content/(plugins|themes)/, capture the plugin/theme name, then capture the version number if available. The new regex executed in well under 1s against the same site that the original regex hung up on for over 10 minutes.