### PR TITLE
Reset wpparamuser between scans in list mode.

### DIFF
--- a/deepscans/wp/userenum.py
+++ b/deepscans/wp/userenum.py
@@ -62,13 +62,14 @@ def start(id, url, ua, ga, source):
 
     # the regular way of checking vua user Parameter -- For now just check upto 20 ids
     cmseek.info('Harvesting usernames from wordpress author Parameter')
+    global wpparamuser
+    wpparamuser = []
     usrrange = range(31) # ain't it Obvious
     threads = [threading.Thread(target=wpauthorenum, args=(ua,url,r)) for r in usrrange]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
-    global wpparamuser
     # Combine all the usernames that we collected
     usernames = set(wpjsonuser+jpapiuser+wpparamuser)
     if len(usernames) > 0:


### PR DESCRIPTION
When running in list mode against multiple WordPress sites the `wpparamuser` list isn't reset between scans. If users are detected using this method then they are reported for each subsequent WordPress site in the list.

This PR fixes that by resetting the global `wpparamuser` variable before launching the `wpauthorenum` threads.