### PR TITLE
Updated setup.py to correct a typo w/ license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,11 +113,11 @@ setup(
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,
-    license='MIT',
+    license='GPLv3+',
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
The setup.py file accidently say its using the MIT license which is not the case for this project. Updated to the proper license.