### PR TITLE
Fixed not catching exceptions while checking URL

### DIFF
--- a/cmseekdb/basic.py
+++ b/cmseekdb/basic.py
@@ -519,7 +519,8 @@ def check_url(url,ua):
     try:
         urllib.request.urlopen(request)
         return '1'
-    except urllib.request.HTTPError:
+    except Exception as e:
+        error(str(e))
         return '0'
 
 def wpbrutesrc(url, user, pwd):


### PR DESCRIPTION
This method constantly fails while running cmseek with a large batch of domains with various exceptions (remote disconnected, SSL shake failed, etc.).