### PR TITLE
Add Hugo detector and version definition

### DIFF
--- a/VersionDetect/detect.py
+++ b/VersionDetect/detect.py
@@ -269,3 +269,6 @@ def start(id, url, ua, ga, source, ga_content, headers):
         import VersionDetect.godaddywb as godaddywbverdetect
         godaddywb_version = godaddywbverdetect.start(ga_content)
         return godaddywb_version
+    elif id == 'hugo':
+        import VersionDetect.hugo as hugodetect
+        return hugodetect.start(source)

--- a/VersionDetect/hugo.py
+++ b/VersionDetect/hugo.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# This is a part of CMSeeK, check the LICENSE file for more information
+# Copyright (c) 2022 Konstantin Shibkov
+
+## Hugo version detection
+## Rev 1
+
+import cmseekdb.basic as cmseek
+import re
+
+def start(source):
+    version = '0'
+    cmseek.statement('Detecting Version')
+    cmseek.statement('Generator Tag Available... Trying version detection using generator meta tag')
+    rr = re.findall(r'<meta name=[\"]*generator[\"]* content=\"Hugo (.*?)\"', source)
+    if rr != []:
+        version = rr[0]
+        cmseek.success(cmseek.bold + cmseek.fgreen + "Version Detected, Hugo Version %s" % version + cmseek.cln)
+    return version

--- a/cmseekdb/cmss.py
+++ b/cmseekdb/cmss.py
@@ -1186,3 +1186,10 @@ ipo = {
     'vd':'0',
     'deeps':'0'
 }
+
+hugo = {
+    'name':'Hugo',
+    'url':'https://gohugo.io/',
+    'vd':'1',
+    'deeps':'0'
+}

--- a/cmseekdb/generator.py
+++ b/cmseekdb/generator.py
@@ -116,7 +116,8 @@ def scan(content):
                 'amiro.cms||www.amiro.ru:-amiro',
                 'starfield technologies; go daddy website builder:-godaddywb',
                 'opennemas:-opennemas',
-                'zen-cart.com||zen cart:-zencart'
+                'zen-cart.com||zen cart:-zencart',
+                'hugo:-hugo'
     ]
 
     for detection_key in generator_tag_detection_keys:

--- a/cmseekdb/sc.py
+++ b/cmseekdb/sc.py
@@ -131,7 +131,8 @@ def check(page_source_code, site): ## Check if no generator meta tag available
         'js/whmcs.js:-whmcs',
         'OpenNeMaS CMS by Openhost||var u = "https://piwik.openhost.es/":-opennemas',
         'zenid=||Congratulations! You have successfully installed your Zen Cart||Google Code for ZenCart Google||Powered by ZenCart||sideboxpzen-cart||stylesheet_zen_lightbox.css:-zencart',
-        'Redakční systém IPO||cdn.antee.cz/||ipo.min.js:-ipo'
+        'Redakční systém IPO||cdn.antee.cz/||ipo.min.js:-ipo',
+        'Built using HUGO:-hugo'
         ]
 
         for detection_key in page_source_detection_keys:


### PR DESCRIPTION
Add Hugo open-source static site generators engine detector (https://gohugo.io/)

For detect Hugo use:
- meta tag with name generator, also use for version definition

Example: `<meta name="generator" content="Hugo 0.96.0">`

- search text `Built using HUGO` in source

Tests were made on the sites:

- https://gohugo.io/
- https://letsencrypt.org/
- https://www.fleslandflis.no/
- https://sendel.ru
- https://gabriel-cuallado.com/
- https://www.pharmaseal.co/
- https://www.linode.com/docs

[📦 zip archive with results](https://github.com/Tuhinshubhra/CMSeeK/files/8643545/hugo_sites_scan_results.zip)

Thanks for your time!
