### PR TITLE
pre-set utf-8 to prevent error due to different encoding

### DIFF
--- a/cmseekdb/result.py
+++ b/cmseekdb/result.py
@@ -5,6 +5,11 @@
 
 import cmseekdb.basic as cmseek
 
+# For the enviroument that doesn't use utf8
+import sys
+import io
+sys.stdout = io.open(sys.stdout.fileno(), 'w', encoding='utf8')
+
 def target(target):
     ## initiate the result
     target = target.replace('https://','').replace('http://', '').split('/')


### PR DESCRIPTION
Fix errors caused by characters in non-utf8 enviroument

`UnicodeEncodeError: 'ascii' codec can't encode characters in position 1-2: ordinal not in range(128)`