### PR TITLE
Add target_url to result json with input domain

### DIFF
--- a/cmseekdb/basic.py
+++ b/cmseekdb/basic.py
@@ -334,7 +334,7 @@ def handle_quit(end_prog = True):
     if end_prog == True:
         bye()
     else:
-        log = '{"url":"","last_scanned":"","detection_param":"","cms_id":"","cms_name":"","cms_url":""}'
+        log = '{"url":"","last_scanned":"","detection_param":"","cms_id":"","cms_name":"","cms_url":"","target_url":""}'
 
 def update_brute_cache():
     clearscreen()

--- a/cmseekdb/core.py
+++ b/cmseekdb/core.py
@@ -67,6 +67,7 @@ def main_proc(site,cua):
                 headers = tmp_req[2]
             else:
                 cmseek.statement("Skipping redirect to " + cmseek.bold + cmseek.red + init_source[3] + cmseek.cln)
+            cmseek.update_log('target_url', init_source[3])
     if scode == '':
         # silly little check thought it'd come handy
         cmseek.error('Aborting detection, source code empty')
@@ -148,7 +149,6 @@ def main_proc(site,cua):
             if cms_version != '0' and cms_version != None:
                 cmseek.update_log('cms_version', cms_version) # update log
             cmseek.update_log('cms_url', cms_info['url']) # update log
-            cmseek.update_log('target_url', site) # update log
             comptime = round(time.time() - cmseek.cstart, 2)
             log_file = os.path.join(cmseek.log_dir, 'cms.json')
             result.end(str(cmseek.total_requests), str(comptime), log_file)

--- a/cmseekdb/core.py
+++ b/cmseekdb/core.py
@@ -148,6 +148,7 @@ def main_proc(site,cua):
             if cms_version != '0' and cms_version != None:
                 cmseek.update_log('cms_version', cms_version) # update log
             cmseek.update_log('cms_url', cms_info['url']) # update log
+            cmseek.update_log('target_url', site) # update log
             comptime = round(time.time() - cmseek.cstart, 2)
             log_file = os.path.join(cmseek.log_dir, 'cms.json')
             result.end(str(cmseek.total_requests), str(comptime), log_file)

--- a/cmseekdb/core.py
+++ b/cmseekdb/core.py
@@ -67,7 +67,7 @@ def main_proc(site,cua):
                 headers = tmp_req[2]
             else:
                 cmseek.statement("Skipping redirect to " + cmseek.bold + cmseek.red + init_source[3] + cmseek.cln)
-            cmseek.update_log('target_url', init_source[3])
+            cmseek.update_log('target_url', init_source[3].rstrip('/'))
     if scode == '':
         # silly little check thought it'd come handy
         cmseek.error('Aborting detection, source code empty')


### PR DESCRIPTION
I need to have the redirected domain as ### target_url value in cms.json. In the case of the follow-redirect option, we don't have information about the domain after the redirect was processed.