### PR TITLE
Add CMS Detection for Siquando & Freshpage

### DIFF
--- a/cmseekdb/cmss.py
+++ b/cmseekdb/cmss.py
@@ -1233,3 +1233,10 @@ notion = {
     'vd':'0',
     'deeps':'0'
 }
+
+siquando = {
+    'name':'SIQUANDO',
+    'url':'https://www.siquando.de/',
+    'vd':'0',
+    'deeps':'0'
+}

--- a/cmseekdb/cmss.py
+++ b/cmseekdb/cmss.py
@@ -1240,3 +1240,10 @@ siquando = {
     'vd':'0',
     'deeps':'0'
 }
+
+freshpage = {
+    'name':'Freshpage',
+    'url':'https://www.freshpage.ch/',
+    'vd':'0',
+    'deeps':'0'
+}

--- a/cmseekdb/generator.py
+++ b/cmseekdb/generator.py
@@ -120,7 +120,8 @@ def scan(content):
                 'opennemas:-opennemas',
                 'zen-cart.com||zen cart:-zencart',
                 'hugo:-hugo',
-                'squarespace:-squarespace'
+                'squarespace:-squarespace',
+                'siquando pro||siquando:-siquando'
     ]
 
     for detection_key in generator_tag_detection_keys:

--- a/cmseekdb/sc.py
+++ b/cmseekdb/sc.py
@@ -29,7 +29,7 @@ def check(page_source_code, site): ## Check if no generator meta tag available
         "css/joomla.css:-joom",
         "Powered By <a href=\"http://www.opencart.com\">OpenCart||\"catalog/view/javascript/jquery/swiper/css/opencart.css\"||index.php?route=:-oc",
         "/xoops.js||xoops_redirect:-xoops",
-	"tildacdn.com:-tilda",
+	    "tildacdn.com:-tilda",
         "Wolf Default RSS Feed:-wolf",
         "/ushahidi.js||alt=\"Ushahidi\":-ushahidi",
         "getWebguiProperty:-wgui",
@@ -139,7 +139,8 @@ def check(page_source_code, site): ## Check if no generator meta tag available
         'zenid=||Congratulations! You have successfully installed your Zen Cart||Google Code for ZenCart Google||Powered by ZenCart||sideboxpzen-cart||stylesheet_zen_lightbox.css:-zencart',
         'Redakční systém IPO||cdn.antee.cz/||ipo.min.js:-ipo',
         'Built using HUGO:-hugo',
-        'This is Squarespace||End of Squarespace Headers:-squarespace'
+        'This is Squarespace||End of Squarespace Headers:-squarespace',
+        'Developed by Inware AG - www.inware.ch:-freshpage'
         ]
 
         for detection_key in page_source_detection_keys:


### PR DESCRIPTION
Added detection for two additional CMS platforms:
- **Freshpage CMS** – a Swiss-based CMS found on a few websites.
- **Siquando** – an older German-based CMS.